### PR TITLE
Speed up compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,15 +10,35 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+dependencies = [
+ "jobserver",
+ "libc",
+ "shlex",
+]
 
 [[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.168"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "num-bigint"
@@ -74,6 +94,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/chancehudson/rust-witness"
 repository = "https://github.com/chancehudson/rust-witness.git"
 
 [dependencies]
-cc = "1.0"
+cc = {version ="1.2.3", features = ["parallel"]}
 fnv = "1.0.7"
 num-bigint = "0.4.0"
 num-traits = "0.2.0"
@@ -16,7 +16,7 @@ paste = "1.0.0"
 walkdir = "2.5.0"
 
 [build-dependencies]
-cc = "1.0"
+cc = {version ="1.2.3", features = ["parallel"]}
 walkdir = "2.5.0"
 
 [lib]

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -191,7 +191,7 @@ pub fn transpile_wasm(wasmdir: String) {
         }
     }
 
-    // Detect if "libcircuit.c" is up to date and skip compilation in that case
+    // Detect if "libcircuit.a" is up to date and skip compilation in that case
     let libcircuit = Path::new(&circuit_out_dir).join("libcircuit.a");
     let mut libcircuit_modified_time = std::time::SystemTime::UNIX_EPOCH;
     if libcircuit.exists() {

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -122,11 +122,13 @@ pub fn transpile_wasm(wasmdir: String) {
         // The output files are named s00..01.c, s00..02.c, s00..03.c, etc., and a main file named after the wasm file.
         // As there may be multiple wasm files, we need to transpile each wasm file into a separate directory to prevent
         // w2c2 from overwriting the s..x.c files.
-        fs::create_dir(Path::new(&circuit_out_dir).join(Path::new(circuit_name.to_str().unwrap())))
-            .expect("Failed to create circuit output directory");
 
         let circuit_out_dir =
             Path::new(&circuit_out_dir).join(Path::new(circuit_name.to_str().unwrap()));
+
+        if !circuit_out_dir.exists() {
+            fs::create_dir(&circuit_out_dir).expect("Failed to create circuit output directory");
+        }
 
         let out = Path::new(&circuit_out_dir)
             .join(Path::new(path.file_name().unwrap()))

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -84,6 +84,7 @@ pub fn transpile_wasm(wasmdir: String) {
         .flag("-Wno-null-character")
         .flag("-Wno-c2x-extensions");
 
+    let mut last_modified_file = std::time::SystemTime::UNIX_EPOCH;
     for entry in WalkDir::new(wasmdir) {
         let e = entry.unwrap();
         let path = e.path();
@@ -96,7 +97,7 @@ pub fn transpile_wasm(wasmdir: String) {
         if ext != "wasm" {
             continue;
         }
-        // with make source files with the same name as the wasm binary file
+        // make source files with the same name as the wasm binary file
         let circuit_name = path.file_stem().unwrap();
         let circuit_name_compressed = circuit_name
             .to_str()
@@ -117,40 +118,113 @@ pub fn transpile_wasm(wasmdir: String) {
             )
             .as_str(),
         );
+        // w2c2 is using a fixed naming convention when splitting source by the number of functions ("-f n" flag).
+        // The output files are named s00..01.c, s00..02.c, s00..03.c, etc., and a main file named after the wasm file.
+        // As there may be multiple wasm files, we need to transpile each wasm file into a separate directory to prevent
+        // w2c2 from overwriting the s..x.c files.
+        fs::create_dir(Path::new(&circuit_out_dir).join(Path::new(circuit_name.to_str().unwrap())))
+            .expect("Failed to create circuit output directory");
+
+        let circuit_out_dir =
+            Path::new(&circuit_out_dir).join(Path::new(circuit_name.to_str().unwrap()));
+
         let out = Path::new(&circuit_out_dir)
             .join(Path::new(path.file_name().unwrap()))
             .with_extension("c");
-        if out.exists() {
+        // Check if the source file needs to be regenerated
+        if needs_regeneration(path, &out) {
+            // first generate the c source
+            w2c2()
+                .arg("-p")
+                .arg("-m")
+                .arg("-f 1")
+                .arg(path)
+                .arg(out.clone())
+                .spawn()
+                .expect("Failed to spawn w2c2")
+                .wait()
+                .expect("w2c2 command errored");
+
+            let contents = fs::read_to_string(out.clone()).unwrap();
+            // make the data constants static to prevent duplicate symbol errors
+            fs::write(
+                out.clone(),
+                contents.replace("const U8 d", "static const U8 d"),
+            )
+            .expect("Error modifying data symbols");
+        } else {
             println!(
-                "Source file already exists, overwriting: {}",
-                &out.display()
+                "C source files are up to date, skipping transpilation: {}",
+                path.display()
+            );
+            last_modified_file = std::cmp::max(
+                last_modified_file,
+                fs::metadata(&out)
+                    .expect("Failed to read metadata")
+                    .modified()
+                    .expect("Failed to read modified time"),
             );
         }
-        // first generate the c source
-        w2c2()
-            .arg("-p")
-            .arg("-m")
-            .arg(path)
-            .arg(out.clone())
-            .spawn()
-            .expect("Failed to spawn w2c2")
-            .wait()
-            .expect("w2c2 command errored");
-
-        let contents = fs::read_to_string(out.clone()).unwrap();
-        // make the data constants static to prevent duplicate symbol errors
-        fs::write(
-            out.clone(),
-            contents.replace("const U8 d", "static const U8 d"),
-        )
-        .expect("Error modifying data symbols");
 
         builder.file(out.clone());
+        // Add all the files to the builder that start with "s0..." and end with ".c" (the results of w2c2 `-f` flag)
+        for entry in WalkDir::new(circuit_out_dir.clone()) {
+            let e = entry.unwrap();
+            let path = e.path();
+            if path.is_dir() {
+                continue;
+            }
+            let ext = path.extension().and_then(OsStr::to_str).unwrap_or("");
+            if ext != "c" {
+                continue;
+            }
+            if path
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("s0")
+                && path.file_name().unwrap().to_str().unwrap().ends_with(".c")
+            {
+                builder.file(path);
+            }
+        }
     }
 
-    // write filename prefixed handler functions
-    let handlers = Path::new(circuit_out_dir.as_str()).join("handlers.c");
-    fs::write(handlers, handler).expect("Error writing handler source");
+    // Detect if "libcircuit.c" is up to date and skip compilation in that case
+    let libcircuit = Path::new(&circuit_out_dir).join("libcircuit.a");
+    let mut libcircuit_modified_time = std::time::SystemTime::UNIX_EPOCH;
+    if libcircuit.exists() {
+        libcircuit_modified_time = fs::metadata(&libcircuit)
+            .expect("Failed to read metadata")
+            .modified()
+            .expect("Failed to read modified time");
+    }
 
-    builder.compile("circuit");
+    if libcircuit_modified_time < last_modified_file || !libcircuit.exists() {
+        // write filename prefixed handler functions
+        let handlers = Path::new(circuit_out_dir.as_str()).join("handlers.c");
+        fs::write(handlers, handler).expect("Error writing handler source");
+
+        builder.compile("circuit");
+    } else {
+        println!("Compiled circuit is up to date, skipping build");
+    }
+}
+
+fn needs_regeneration(source: &Path, generated: &Path) -> bool {
+    if !generated.exists() {
+        return true;
+    }
+    let source_metadata = fs::metadata(source).expect("Failed to read source metadata");
+    let generated_metadata = fs::metadata(generated).expect("Failed to read generated metadata");
+
+    let source_modified = source_metadata
+        .modified()
+        .expect("Failed to read source modification time");
+    let generated_modified = generated_metadata
+        .modified()
+        .expect("Failed to read generated modification time");
+
+    source_modified > generated_modified
 }


### PR DESCRIPTION
This PR is aimed to solve https://github.com/zkmopro/mopro/issues/249

## Changes

- breaking down the source into multiple files [by using "-f" flag with `w2c2`](https://github.com/turbolent/w2c2?tab=readme-ov-file#separate-compilation);
-  parallelizing their compilation by enabling the [`parallel` feature of `cc`](https://docs.rs/cc/1.2.4/cc/#parallel)

## Benchmarks
The benchmarks were conducted on M2 Air laptop in [mopro test-e2e](https://github.com/zkmopro/mopro/tree/main/test-e2e) for iOS build of [Anon Aadhaar circuit.](https://github.com/zkmopro/mopro/issues/249#issuecomment-2520007204)

### Monolithic C file

| Architecture | WitGen compilation | 
| -------- | -------- | 
| aarch64-apple-ios     | 4181s     | 
| aarch64-apple-ios-sim     |  4867s   | 
| x86_64-apple-ios     |   906s   | 

### `-f 100`, ~10 C files

| Architecture | WitGen compilation | 
| -------- | -------- | 
| aarch64-apple-ios     | 412-451s     | 
| aarch64-apple-ios-sim     |  462-467s   | 
| x86_64-apple-ios     |   85-89s   | 

### `-f 10`, ~90 C files

| Architecture | WitGen compilation | 
| -------- | -------- | 
| aarch64-apple-ios     | 155-161s     | 
| aarch64-apple-ios-sim     |  164-172s   | 
| x86_64-apple-ios     |   55-67s   |

### `-f 1`, ~900 C files

| Architecture | WitGen compilation | 
| -------- | -------- | 
| aarch64-apple-ios     | 60-63s     | 
| aarch64-apple-ios-sim     |  63-69s   | 
| x86_64-apple-ios     |   75-77s   | 

### `-f 1`, `parallel` feature enabled for `cc`

| Architecture | WitGen compilation | 
| -------- | -------- | 
| aarch64-apple-ios     | 29-58s     | 
| aarch64-apple-ios-sim     |  30-37.8s   | 
| x86_64-apple-ios     |   39-41.96s   |

## Benchmark Results
The `-f` value was set to 1 (one function per C source file) to maximize the parallelization.