### PR TITLE
fix: add `rerun-if-changed`, remove `.git` in w2c2, update cc version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "cc"
-version = "1.2.5"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -76,7 +76,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "rust-witness"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cc",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/chancehudson/rust-witness"
 repository = "https://github.com/chancehudson/rust-witness.git"
 
 [dependencies]
-cc = {version ="1.2.3", features = ["parallel"]}
+cc = { version = "1.2.10", features = ["parallel"] }
 fnv = "1.0.7"
 num-bigint = "0.4.0"
 num-traits = "0.2.0"
@@ -16,7 +16,7 @@ paste = "1.0.0"
 walkdir = "2.5.0"
 
 [build-dependencies]
-cc = {version ="1.2.3", features = ["parallel"]}
+cc = { version = "1.2.10", features = ["parallel"] }
 walkdir = "2.5.0"
 
 [lib]

--- a/build_w2c2.sh
+++ b/build_w2c2.sh
@@ -16,6 +16,7 @@ fi
 
 rm -rf $BUILD_DIR
 git clone --recursive https://github.com/turbolent/w2c2 $BUILD_DIR
+rm -rf $BUILD_DIR/.git
 
 # if any argument is supplied just clone (to access the headers)
 if [ ! -z $1 ]; then

--- a/build_w2c2.sh
+++ b/build_w2c2.sh
@@ -16,7 +16,6 @@ fi
 
 rm -rf $BUILD_DIR
 git clone --recursive https://github.com/turbolent/w2c2 $BUILD_DIR
-rm -rf $BUILD_DIR/.git
 
 # if any argument is supplied just clone (to access the headers)
 if [ ! -z $1 ]; then

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -61,7 +61,8 @@ pub fn transpile_wasm(wasmdir: String) {
     if !Path::is_dir(Path::new(wasmdir.as_str())) {
         panic!("wasmdir must be a directory");
     }
-
+    println!("cargo:rerun-if-changed={}", wasmdir);
+    
     let (w2c2, w2c2_path) = w2c2_cmd();
 
     let circuit_out_dir = env::var("OUT_DIR").unwrap();

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -62,7 +62,7 @@ pub fn transpile_wasm(wasmdir: String) {
         panic!("wasmdir must be a directory");
     }
     println!("cargo:rerun-if-changed={}", wasmdir);
-    
+
     let (w2c2, w2c2_path) = w2c2_cmd();
 
     let circuit_out_dir = env::var("OUT_DIR").unwrap();


### PR DESCRIPTION
- add `println!("cargo:rerun-if-changed={}", wasmdir);`
   If there is a change in `wasmdir`, rerun transpile
   Fix: https://github.com/zkmopro/mopro/issues/298
- remove `.git` status
   if the directory is without `.git`, it tracks the `target/` `.git` status
   <img width="518" alt="截圖 2025-01-19 下午2 47 08" src="https://github.com/user-attachments/assets/787b911d-4e43-4d1b-bf7a-a1fb5e999f41" />

- update `cc` version