### PR TITLE
docs: update requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,16 @@ sh ./install_w2c2.sh
 ```
 
 `transpile_wasm` will automatically use the `w2c2` in your `$PATH` if possible.
+
+## Toolchain Requirements
+
+Using `rust-witness` in another crate requires Rust 1.81.0 to be installed in the environment. The toolchain can be installed with the following command:
+
+```sh
+rustup install 1.81.0
+```
+
+Without the correct toolchain, errors similar to the following may occur:
+```sh 
+error: linking with `cc` failed: exit status: 1
+```


### PR DESCRIPTION
Tested at https://github.com/sifnoc/rust_witness_test/actions/runs/12904150297/job/35980761177#step:5:39

Checked version
```sh
+ rustup show
Default host: x86_64-unknown-linux-gnu
rustup home:  /home/runner/.rustup

installed toolchains
--------------------

stable-x86_64-unknown-linux-gnu (default)
nightly-20[24](https://github.com/sifnoc/rust_witness_test/actions/runs/12904150297/job/35980761177#step:5:25)-07-18-x86_64-unknown-linux-gnu
1.81.0-x86_64-unknown-linux-gnu

active toolchain
----------------

1.81.0-x86_64-unknown-linux-gnu (directory override for '/home/runner/work/rust_witness_test/rust_witness_test')
rustc 1.81.0 (eeb90cda1 2024-09-04)
```

In 1.84.0 installed, got error like at https://github.com/sifnoc/rust_witness_test/actions/runs/12904095695/job/35980604892#step:7:26