### PR TITLE
feat: enhance witness macro with C function bindings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,13 @@ pub mod transpile;
 macro_rules! witness {
     ($x: ident) => {
         rust_witness::paste::item! {
+            mod [<$x _witness_c>] {
+                extern "C" {
+                    pub fn witness_c_init() -> *mut std::ffi::c_void;
+                    pub fn witness_c_resolver() -> *mut std::ffi::c_void;
+                    pub fn witness_c_cleanup(instance: *mut std::ffi::c_void);
+                }
+            }
             extern "C" {
                 pub fn [<$x Instantiate>](i: *mut std::ffi::c_void, resolveImports: *mut std::ffi::c_void);
                 pub fn [<$x FreeInstance>](i: *mut std::ffi::c_void);
@@ -22,13 +29,29 @@ macro_rules! witness {
                 pub fn [<$x _getWitness>](i: *mut std::ffi::c_void, l0: u32);
                 pub fn [<$x _init>](i: *mut std::ffi::c_void, l0: u32);
             }
+
+            // Public functions to make the above functions accessible
+            // in the crate namespace
+            pub fn [<$x _c_init>]() -> *mut std::ffi::c_void {
+                unsafe { [<$x _witness_c>]::witness_c_init() }
+            }
+
+            pub fn [<$x _c_resolver>]() -> *mut std::ffi::c_void {
+                unsafe { [<$x _witness_c>]::witness_c_resolver() }
+            }
+
+            pub fn [<$x _c_cleanup>](v: *mut std::ffi::c_void) {
+                unsafe {
+                    [<$x _witness_c>]::witness_c_cleanup(v);
+                }
+            }
         }
         rust_witness::paste::item! {
             pub fn [<$x _witness>]<I: IntoIterator<Item = (String, Vec<rust_witness::BigInt>)>>(inputs: I) -> Vec<rust_witness::BigInt> {
                 // used for keying the values to signals
                 unsafe {
-                    let instance = rust_witness::c_init();
-                    let resolver = rust_witness::c_resolver();
+                    let instance = [<$x _c_init>]();
+                    let resolver = [<$x _c_resolver>]();
                     // instantiate the memory structures
 
                     [<$x Instantiate>](instance, resolver);
@@ -80,7 +103,7 @@ macro_rules! witness {
 
                     // cleanup the c memory
                     [<$x FreeInstance>](instance);
-                    rust_witness::c_cleanup(instance);
+                    [<$x _c_cleanup>](instance);
 
                     w
 
@@ -103,29 +126,6 @@ macro_rules! witness {
             }
         }
     };
-}
-
-// shared global functions
-extern "C" {
-    pub fn witness_c_init() -> *mut std::ffi::c_void;
-    pub fn witness_c_resolver() -> *mut std::ffi::c_void;
-    pub fn witness_c_cleanup(instance: *mut std::ffi::c_void);
-}
-
-// Public functions to make the above functions accessible
-// in the crate namespace
-pub fn c_init() -> *mut std::ffi::c_void {
-    unsafe { witness_c_init() }
-}
-
-pub fn c_resolver() -> *mut std::ffi::c_void {
-    unsafe { witness_c_resolver() }
-}
-
-pub fn c_cleanup(v: *mut std::ffi::c_void) {
-    unsafe {
-        witness_c_cleanup(v);
-    }
 }
 
 pub fn fnv(inp: &str) -> (u32, u32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,15 +32,15 @@ macro_rules! witness {
 
             // Public functions to make the above functions accessible
             // in the crate namespace
-            pub fn [<$x _c_init>]() -> *mut std::ffi::c_void {
+            pub unsafe fn [<$x _c_init>]() -> *mut std::ffi::c_void {
                 unsafe { [<$x _witness_c>]::witness_c_init() }
             }
 
-            pub fn [<$x _c_resolver>]() -> *mut std::ffi::c_void {
+            pub unsafe fn [<$x _c_resolver>]() -> *mut std::ffi::c_void {
                 unsafe { [<$x _witness_c>]::witness_c_resolver() }
             }
 
-            pub fn [<$x _c_cleanup>](v: *mut std::ffi::c_void) {
+            pub unsafe fn [<$x _c_cleanup>](v: *mut std::ffi::c_void) {
                 unsafe {
                     [<$x _witness_c>]::witness_c_cleanup(v);
                 }


### PR DESCRIPTION
Added C function bindings for initialization, resolver, and cleanup within the witness macro. Updated the macro to use these new bindings instead of the previous global functions, improving encapsulation and organization of the code.

Fix the error
```sh
/rust-witness/src/lib.rs:118:(.text._ZN12rust_witness6c_init17hbda9399f5fcd6684E+0x8): undefined reference to `witness_c_init'
          /usr/bin/ld: /rust_witness_test/target/debug/deps/librust_witness-80a47b4b3377cedd.rlib(rust_witness-80a47b4b3377cedd.e6e09n2bx9w7cffqksty9zsex.1hm3j8m.rcgu.o): in function `rust_witness::c_resolver':
          /rust-witness/src/lib.rs:122:(.text._ZN12rust_witness10c_resolver17heb60d833fb3f4c32E+0x8): undefined reference to `witness_c_resolver'
          /usr/bin/ld: /rust_witness_test/target/debug/deps/librust_witness-80a47b4b3377cedd.rlib(rust_witness-80a47b4b3377cedd.e6e09n2bx9w7cffqksty9zsex.1hm3j8m.rcgu.o): in function `rust_witness::c_cleanup':
          /rust-witness/src/lib.rs:127:(.text._ZN12rust_witness9c_cleanup17h57349c740fff551dE+0x14): undefined reference to `witness_c_cleanup'
          collect2: error: ld returned 1 exit status
```
when upgrade to latest rust version
the witness functions are generated in the downstream packages e.g. (`rust_witness_test`, `mopro_ffi`,...)
so the functions should be defined in the downstream packages (with macro)

result: https://github.com/vivianjeng/rust_witness_test/actions/runs/16897352495/job/47869538985